### PR TITLE
Behaviour when no plans specified

### DIFF
--- a/roundup.sh
+++ b/roundup.sh
@@ -78,7 +78,7 @@ if [ "$#" -gt "0" ]
 then
     roundup_plans="$@"
 else
-    roundup_plans="$(ls *-test.sh)"
+    roundup_plans="$(ls t/*-test.sh)"
 fi
 
 : ${color:="auto"}


### PR DESCRIPTION
When no plans are specified, the documentation says that roundup will run $PWD/t/-test.sh when in fact it runs $PWD/-test.sh. Should the documentation be fixed to match the behaviour, or the behaviour be fixed to match the documentation?
