### PR TITLE
CI Server Fixes

### DIFF
--- a/roundup.sh
+++ b/roundup.sh
@@ -166,7 +166,7 @@ roundup_summarize() {
     # __Test Summary__
     #
     # Display the summary now that all tests are finished.
-    yes = | head -n 57 | tr -d '\n'
+    printf '=%.0s' {1..57}
     printf "\n"
     printf "Tests:  %3d | " $ntests
     printf "Passed: %3d | " $passed
@@ -220,7 +220,8 @@ do
 
         # We have the test plan and are in our sandbox with [roundup(5)][r5]
         # defined.  Now we source the plan to bring its tests into scope.
-        . ./$roundup_p
+        roundup_p_dir=`dirname $roundup_p`
+        . `cd $roundup_p_dir && pwd`/`basename $roundup_p`
 
         # Output the description signal
         printf "d %s" "$roundup_desc" | tr "\n" " "


### PR DESCRIPTION
It turns out that using `yes` blocks Apache Ant, so I swapped out that line for another printf call.

Also, I came across the absolute path to spec problem, so I applied the old `cd $file && pwd` bromide.
