### PR TITLE
lookup test functions at runtime to enable meta-programming

### DIFF
--- a/roundup.sh
+++ b/roundup.sh
@@ -207,20 +207,15 @@ do
         before() { :; }
         after() { :; }
 
-        # Seek test methods and aggregate their names, forming a test plan.
-        # This is done before populating the sandbox with tests to avoid odd
-        # conflicts.
-
-        # TODO:  I want to do this with sed only.  Please send a patch if you
-        # know a cleaner way.
-        roundup_plan=$(
-            grep "^it_.*()" $roundup_p           |
-            sed "s/\(it_[a-zA-Z0-9_]*\).*$/\1/g"
-        )
-
         # We have the test plan and are in our sandbox with [roundup(5)][r5]
         # defined.  Now we source the plan to bring its tests into scope.
         . ./$roundup_p
+
+        # Seek test methods and aggregate their names, forming a test plan.
+        roundup_plan=$(
+           compgen -A function |
+           grep "it_.*"
+        )
 
         # Output the description signal
         printf "d %s" "$roundup_desc" | tr "\n" " "


### PR DESCRIPTION
With this patch it's possible to define tests like this:

``` bash
for cmd in \
  "ls"     \
  "pwd"    \
  "id"     \
  "ps"     \
  "uptime" \
  "hey"    \
  "mum"
do
  eval "                    \
    it_can_execute_$cmd() { \
        $cmd;               \
    }"
done
```

**Caveat:** It also changes the order of the tests to alphabetical order.

Cool?
