### PR TITLE
Use posix compliant "set -E" instead of "set -o errtrace"

### DIFF
--- a/roundup-5-test.sh
+++ b/roundup-5-test.sh
@@ -100,3 +100,30 @@ it_outputs_the_return_code_7() {
 xit_ignores_this() {
     false
 }
+
+# Roundup will check assume statements. It is possible to pass another
+# testcase to assume like it_... or you can pass another shell test. 
+it_passes_with_fulfilled_assumptions() {
+    assume it_passes
+    ! assume it_works_wonders
+    assume ! test -f non_existing_file
+}
+
+# Roundup's behaviour is not changed if only fulfilled assumptions are
+# used in a testcase.
+it_fails_with_assumptions() {
+    ! assume it_works_wonders
+    false
+}
+
+# Roundup will skip testcases where the assumptions are partially not
+# fulfilled.
+it_is_skipped_without_assumptions() {
+    assume it_works_wonders
+}
+
+# Roundup will skip testcases where the shell test is partially not
+# fulfilled.
+it_is_skipped_with_failing_test() {
+    assume test -z "bla"
+}

--- a/roundup.sh
+++ b/roundup.sh
@@ -134,15 +134,17 @@ roundup_summarize() {
         red=$(printf "\033[31m")
         grn=$(printf "\033[32m")
         mag=$(printf "\033[35m")
+        ylw=$(printf "\033[33m")
         clr=$(printf "\033[m")
         cols=$(tput cols)
     fi
 
     # Make these available to `roundup_trace`.
-    export red grn mag clr
+    export red grn mag clr ylw
 
     ntests=0
     passed=0
+    skipped=0
     failed=0
 
     : ${cols:=10}
@@ -155,6 +157,12 @@ roundup_summarize() {
             passed=$(expr $passed + 1)
             printf "  %-48s " "$name:"
             printf "$grn[PASS]$clr\n"
+            ;;
+        s)
+            ntests=$(expr $ntests + 1)
+            skipped=$(expr $skipped + 1)
+            printf "  %-48s " "$name:"
+            printf "$ylw[SKIP]$clr\n"
             ;;
         f)
             ntests=$(expr $ntests + 1)
@@ -173,9 +181,10 @@ roundup_summarize() {
     # Display the summary now that all tests are finished.
     yes = | head -n 57 | tr -d '\n'
     printf "\n"
-    printf "Tests:  %3d | " $ntests
-    printf "Passed: %3d | " $passed
-    printf "Failed: %3d"    $failed
+    printf "Tests:   %3d | " $ntests
+    printf "Passed:  %3d | " $passed
+    printf "Skipped: %3d | " $skipped
+    printf "Failed:  %3d"    $failed
     printf "\n"
 
     # Exit with an error if any tests failed
@@ -205,6 +214,25 @@ do
         # TODO: reimplement this.
         describe() {
             roundup_desc="$*"
+        }
+
+        # Helper to express an assumption for a given testcase. Example:
+        # it_runs_fine() {
+        #   assume it_builds_fine
+        #   assume test -f foo
+        #   ./binary
+        # }
+        assume() {
+            if (echo "$1" | grep "^it_.*" >/dev/null)
+            then if [ "$(eval echo \${passed_$1})" == 1 ]
+                 then return 0
+                 else return 253
+                 fi
+            else if eval "$@"
+                 then return 0
+                 else return 253
+                 fi
+            fi
         }
 
         # Provide default `before` and `after` functions that run only `:`, a
@@ -291,9 +319,11 @@ do
 
                 # This is the final step of a test.  Print its pass/fail signal
                 # and name.
-                if [ "$roundup_result" -ne 0 ]
-                then printf "f"
-                else printf "p"
+                if [ "$roundup_result" == 0 ]
+                then printf "p"; eval export passed_$roundup_test_name=1
+                elif [ "$roundup_result" == 253 ]
+                then printf "s"
+                else printf "f"
                 fi
 
                 printf " $roundup_test_name\n"


### PR DESCRIPTION
This fixes roundup to work with dash.
