### PR TITLE
Print trace of before function on error

### DIFF
--- a/roundup.sh
+++ b/roundup.sh
@@ -232,8 +232,18 @@ do
             # test.  Drop into an subshell to contain operations that may throw
             # off roundup; such as `cd`.
             (
-                # If `before` wasn't redefined, then this is `:`.
-                before
+                # Output `before` trace to temporary file. If `before` runs cleanly,
+                # the trace will be overwritten by the actual test case below.
+                {
+                    # redirect tracing output of `before` into file.
+                    {
+                        set -x
+                        # If `before` wasn't redefined, then this is `:`.
+                        before
+                    } &>"$roundup_tmp/$roundup_test_name"
+                    # disable tracing again. Its trace output goes to /dev/null.
+                    set +x
+                } &>/dev/null
 
                 # Momentarily turn off auto-fail to give us access to the tests
                 # exit status in `$?` for capturing.


### PR DESCRIPTION
If the before function fails for some reason, you have no clue about the reason until now. This patches traces it as well. If the before function passes, the behavior is not changed, i.e. there is not a trace of it.
