### PR TITLE
Fix multiple invocations of the `before` function and `before` tracing

### DIFF
--- a/roundup-1-test.sh
+++ b/roundup-1-test.sh
@@ -46,3 +46,8 @@ it_exits_non_zero() {
 it_survives_edge_cases() {
     rup edge
 }
+
+it_exits_non_zero_on_broken_before () {
+    status=$(set +e ; rup roundup-5 >/dev/null ; echo $?)
+    test 2 -eq $status
+}

--- a/roundup-before-test.sh
+++ b/roundup-before-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env roundup
+#
+# This Will Fail
+# --------------
+#
+# The before function 
+describe "roundup before trace"
+
+# This `before` function is run before it_works. The `false` will simulate
+# an error. Hence, `it_works` should not be called at all, but it should be
+# marked as failed and the `before` trace should be displayed.
+before () {
+	false
+}
+
+# A trivial and correct test case. But because `before` is broken, this 
+# testcase will fail as well.
+it_works () {
+	true
+}


### PR DESCRIPTION
1. The `before` function had been called twice, once with proper tracing and error
   output redirection and once directly. This is fixed now.
2. The result output was moved out of the inner subshell. This is necessary
   because: in case the `before` function has an error, roundup's error trap is
   triggered and the inner subshell is left. Still, we need a proper result ouput.
3. A test case with a broken `before` function was added which gives
   the following output:
   
   roundup before trace
     it_works:                                        [FAIL]
       + false
       exit code 1

for the following before function:

  before () {
    false
  }
