### PR TITLE
mkdir: Unquoted path with whitespace fails

### DIFF
--- a/roundup.sh
+++ b/roundup.sh
@@ -86,7 +86,7 @@ fi
 # Create a temporary storage place for test output to be retrieved for display
 # after failing tests.
 roundup_tmp="$PWD/.roundup.$$"
-mkdir -p $roundup_tmp
+mkdir -p "$roundup_tmp"
 
 trap "rm -rf \"$roundup_tmp\"" EXIT INT
 


### PR DESCRIPTION
The path for the mkdir command on line 89 was not quoted, resulting in the target directory not being created if the directory path of the directory where roundup is stored in contains any whitespace.
