### PR TITLE
If /bin/sh = dash then use /bin/bash instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build: roundup
 
 roundup: roundup.sh FORCE
 	$(SHELL) -n roundup.sh
-	cp roundup.sh roundup
+	sed "s~#!/bin/sh~#!${SHELL}~" roundup.sh > roundup
 	chmod 0755 roundup
 
 test: roundup

--- a/configure
+++ b/configure
@@ -167,7 +167,11 @@ echo "building for ${UNAME:-unknown}" \
 
 looking "for /bin/sh"
 SH=$(have /bin/sh) && {
-    if expr "$("$SH" --version 2>/dev/null)" : '.*bash' >/dev/null
+    if test $(readlink /bin/sh) = dash
+    then
+        SH=/bin/bash
+        found '' "oh ick, it looks like dash. Setting SH to $SH"
+    elif expr "$("$SH" --version 2>/dev/null)" : '.*bash' >/dev/null
     then
         found '' "oh ick, it looks like bash"
     else

--- a/roundup-1-test.sh
+++ b/roundup-1-test.sh
@@ -25,7 +25,7 @@
 # ------------
 
 # Prevent carpel tunnel
-rup() { /bin/sh $0 $1-test.sh ; }
+rup() { $SHELL $0 $1-test.sh ; }
 
 # The Plan
 # --------


### PR DESCRIPTION
This prevents `trap: ERR: bad trap` errors on systems like Debian/Ubuntu.

Fixes GH-25
