### PR TITLE
roundup-test-5.sh: Remove `function` keyword

### DIFF
--- a/roundup-5-test.sh
+++ b/roundup-5-test.sh
@@ -87,10 +87,10 @@ it_runs_after_if_a_test_fails_part_2() {
 
 # Output the correct return code of a failing command of a testcase.
 it_outputs_the_return_code_7() {
-    function f() { return 42; }
+    f() { return 42; }
     x=$(echo asdf)
 
-    function g() { return 7; }
+    g() { return 7; }
     g
 }
 


### PR DESCRIPTION
for greater POSIX compatibility

Without this, bash 4.2.25, in particular, on my Ubuntu system chokes with:

```
./roundup: 90: ./roundup-5-test.sh: Syntax error: "(" unexpected (expecting "}")
```
