### PR TITLE
Fix cross references in man pages

### DIFF
--- a/roundup.1.ronn
+++ b/roundup.1.ronn
@@ -44,7 +44,7 @@ Blake Mizerany (bmizerany)
 
 ## SEE ALSO
 
-roundup(1), test(1)
+roundup(5), test(1)
 
 ## NOTES
 

--- a/roundup.5.ronn
+++ b/roundup.5.ronn
@@ -53,7 +53,7 @@ roundup(5) -- test-plan file format for roundup(1)
 
 ## SEE ALSO
 
-  roundup(5), test(1)
+  roundup(1), test(1)
 
 ## NOTES
 


### PR DESCRIPTION
roundup(1) should reference in "SEE ALSO" roundup(5), and vice versa.
