### PR TITLE
Adds support for later.

### DIFF
--- a/roundup-later-test.sh
+++ b/roundup-later-test.sh
@@ -1,0 +1,7 @@
+# `describe` the plan meaningfully.
+describe "roundup later testing"
+
+it_can_work_with_later() {
+  later "This will fail"
+  false
+}


### PR DESCRIPTION
The later command cancels a test case without failing the test. The
test status will be printed as "[LATER]", and the count of all tests
cancelled with later appears in the summary.
