### PR TITLE
Preserve log output by test into logs/ directory.

### DIFF
--- a/roundup.sh
+++ b/roundup.sh
@@ -153,21 +153,22 @@ roundup_summarize() {
 
     : ${cols:=10}
 
-    while read status name
+    while read status name logfn
     do
         case $status in
         p)
             ntests=$(expr $ntests + 1)
             passed=$(expr $passed + 1)
             printf "  %-48s " "$name:"
-            printf "$grn[PASS]$clr\n"
+            printf "$grn[PASS]$clr $logfn\n"
             ;;
         f)
             ntests=$(expr $ntests + 1)
             failed=$(expr $failed + 1)
             printf "  %-48s " "$name:"
-            printf "$red[FAIL]$clr\n"
-            roundup_trace < "$roundup_tmp/$name"
+            printf "$red[FAIL]$clr $logfn\n"
+
+            test -n "$logfn" -a -f "$logfn" || roundup_trace < "$roundup_tmp/$name"
             ;;
         d)
             printf "%s\n" "$name"
@@ -290,6 +291,13 @@ do
                 # If `after` wasn't redefined, then this runs `:`.
                 after
 
+                # Preserve test outputs for every test
+                logfn=""
+                test -d logs/ && {
+                    logfn="logs/$roundup_p-${roundup_test_name}.log";
+                    cp "$roundup_tmp/$roundup_test_name" "$logfn"
+                }
+
                 # This is the final step of a test.  Print its pass/fail signal
                 # and name.
                 if [ "$roundup_result" -ne 0 ]
@@ -297,7 +305,7 @@ do
                 else printf "p"
                 fi
 
-                printf " $roundup_test_name\n"
+                printf " $roundup_test_name $logfn\n"
             )
         done
     )


### PR DESCRIPTION
This feature enables logging output of each Test into "logs/$roundup_p-${roundup_test_name}.log" file.

For example I have about 100 tests for a single project and roundup is running via crond on a nightly basis.
Idea is to send generic report about PASS and FAIL tests via email (roundup stdout)
and put log filename nearby.

This feature is only enabled if "logs/" directory exists in the current dir and turned off by default.

Output example:
00-mkproxy-config
  it_has_mkproxy_home:      [PASS] logs/00-mkproxy-config-test.sh-it_has_mkproxy_home.log
  it_uses_profie_config:        [PASS] logs/00-mkproxy-config-test.sh-it_uses_profie_config.log
  it_found_java:                     [PASS] logs/00-mkproxy-config-test.sh-it_found_java.log
  it_found_java_version:                           [PASS] logs/00-mkproxy-config-test.sh-it_found_java_version.log
  it_found_uberjar:                                [PASS] logs/00-mkproxy-config-test.sh-it_found_uberjar.log
  it_found_static_bins:                            [FAIL] logs/00-mkproxy-config-test.sh-it_found_static_bins.log
  it_found_python_depenencies:                     [PASS] logs/00-mkproxy-config-test.sh-it_found_python_depenencies.log
