### PR TITLE
Makefile: fix dependency of install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ else
 	exit 1
 endif
 
-install: $(INSTALL_PREREQUISITES)
+install: build
 	test -f roundup
 	mkdir -p "$(bindir)"
 	cp roundup "$(bindir)/roundup"


### PR DESCRIPTION
`make install` should always work even there was no preceding `make` or `make build`, but `$(INSTALL_PREREQUISITES)` was not defined anywhere, so running `make install` directly caused `test -f roundup` to fail.
