### PR TITLE
Only use errtrace in shells that support it

### DIFF
--- a/roundup-5-test.sh
+++ b/roundup-5-test.sh
@@ -87,10 +87,10 @@ it_runs_after_if_a_test_fails_part_2() {
 
 # Output the correct return code of a failing command of a testcase.
 it_outputs_the_return_code_7() {
-    function f() { return 42; }
+    f() { return 42; }
     x=$(echo asdf)
 
-    function g() { return 7; }
+    g() { return 7; }
     g
 }
 

--- a/roundup.sh
+++ b/roundup.sh
@@ -258,9 +258,11 @@ do
 
                 # exit subshell with return code of last failing command. This
                 # is needed to see the return code 253 on failed assumptions.
-                # But, only do this if the error handling is activated.
-                set -E
-                trap 'rc=$?; set +x; set -o | grep "errexit.*on" >/dev/null && exit $rc' ERR
+                # But, only do this if the error handling is activated and only if the shell supports it
+                if set -o | grep "^errtrace" >/dev/null; then
+                  set -o errtrace
+                  trap 'rc=$?; set +x; set -o | grep "errexit.*on" >/dev/null && exit $rc' ERR
+                fi
 
                 # If `before` wasn't redefined, then this is `:`.
                 before


### PR DESCRIPTION
Using the -E / errtrace option from the bash builtins breakes roundup
on shells that do not support it, eg. busyboxs' sh.
The same goes for the bash specific ERR signal which is not POSIX
compliant. Both should only be used if roundup is executed in a shell
that support it.
